### PR TITLE
feat: add PIPELIT_REPO and PIPELIT_REF build args to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 # Stage 1: Clone Pipelit
 FROM alpine/git:latest AS pipelit-source
-RUN git clone --depth 1 https://github.com/theuselessai/Pipelit.git /pipelit
+ARG PIPELIT_REPO=https://github.com/theuselessai/Pipelit.git
+ARG PIPELIT_REF=master
+RUN git clone --depth 1 --branch "$PIPELIT_REF" "$PIPELIT_REPO" /pipelit
 
 # Stage 2: Build plit + plit-gw
 FROM rust:1-bookworm AS rust-builder


### PR DESCRIPTION
## Summary

- Add `PIPELIT_REPO` and `PIPELIT_REF` build args to Dockerfile Stage 1
- Defaults to `master` from `theuselessai/Pipelit.git` for production builds
- CI can override to build with a specific Pipelit branch (e.g. PR branch for E2E testing)

Companion to theuselessai/Pipelit#159 (E2E CI infrastructure).

Refs #5