### PR TITLE
ci: add release workflow with RC/stable lifecycle and GHCR publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,137 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+  packages: write
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: theuselessai/plit
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.meta.outputs.version }}
+      is_rc: ${{ steps.meta.outputs.is_rc }}
+      image_digest: ${{ steps.push.outputs.digest }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Extract version metadata
+        id: meta
+        run: |
+          VERSION="${GITHUB_REF#refs/tags/v}"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          if [[ "$VERSION" == *-rc* ]]; then
+            echo "is_rc=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "is_rc=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build Docker image
+        run: |
+          docker build \
+            --build-arg PIPELIT_REF=master \
+            -t ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }} \
+            .
+
+      - name: Push Docker image
+        id: push
+        run: |
+          docker push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}
+          DIGEST=$(docker inspect --format='{{index .RepoDigests 0}}' ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }} | cut -d@ -f2)
+          echo "digest=$DIGEST" >> "$GITHUB_OUTPUT"
+
+      - name: Tag as latest (stable only)
+        if: steps.meta.outputs.is_rc == 'false'
+        run: |
+          docker tag \
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }} \
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+          docker push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+
+  e2e:
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout Pipelit (for E2E scripts)
+        uses: actions/checkout@v4
+        with:
+          repository: theuselessai/Pipelit
+          ref: master
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Pull built image
+        run: |
+          docker pull ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.build.outputs.version }}
+          docker tag ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.build.outputs.version }} plit-e2e:local
+
+      - name: Run E2E (smoke for RC, full for stable)
+        env:
+          ANTHROPIC_API_KEY: ${{ needs.build.outputs.is_rc == 'false' && secrets.ANTHROPIC_API_KEY || '' }}
+        run: ./e2e/run_smoke.sh plit-e2e:local
+
+      - name: Container logs on failure
+        if: failure()
+        run: |
+          for c in $(docker ps -a --filter name=plit-e2e-smoke --format '{{.Names}}'); do
+            echo "=== Logs: $c ==="
+            docker logs "$c" 2>&1 | tail -100
+          done
+
+  release:
+    needs: [build, e2e]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Create GitHub Release
+        uses: ncipollo/release-action@v1
+        with:
+          tag: v${{ needs.build.outputs.version }}
+          name: v${{ needs.build.outputs.version }}
+          prerelease: ${{ needs.build.outputs.is_rc == 'true' }}
+          makeLatest: ${{ needs.build.outputs.is_rc == 'false' }}
+          generateReleaseNotes: true
+          body: |
+            ## Docker
+
+            ```sh
+            docker pull ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.build.outputs.version }}
+            ```
+
+  publish-crate:
+    needs: [build, e2e]
+    runs-on: ubuntu-latest
+    # Only publish to crates.io for stable releases
+    if: needs.build.outputs.is_rc == 'false'
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Publish to crates.io
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: cargo publish --no-verify


### PR DESCRIPTION
## Summary

- Add tag-driven release workflow (`.github/workflows/release.yml`)
- RC tags (`vX.Y.Z-rc.N`): build Docker image → smoke E2E (mock LLM) → GHCR `:X.Y.Z-rc.N` + GitHub prerelease
- Stable tags (`vX.Y.Z`): build Docker image → full E2E (real Anthropic key) → GHCR `:X.Y.Z` + `:latest` + crates.io + GitHub stable release
- E2E scripts pulled from Pipelit repo (Pipelit#159)

## Flow

```
Tag v0.4.0-rc.1 → build → smoke E2E → GHCR :0.4.0-rc.1 + prerelease
Tag v0.4.0       → build → full E2E  → GHCR :0.4.0 + :latest + crates.io + stable release
```

Refs #5