### PR TITLE
feat: curl installer + musl release binaries for all platforms

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,8 +31,8 @@ jobs:
             echo "is_rc=false" >> "$GITHUB_OUTPUT"
           fi
 
-  # RC: build image, run full E2E, push to GHCR
-  build:
+  # RC: build Docker image, run full E2E, push to GHCR
+  build-docker:
     needs: meta
     if: needs.meta.outputs.is_rc == 'true'
     runs-on: ubuntu-latest
@@ -57,7 +57,7 @@ jobs:
         run: docker push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.meta.outputs.version }}
 
   e2e:
-    needs: [meta, build]
+    needs: [meta, build-docker]
     if: needs.meta.outputs.is_rc == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -93,7 +93,86 @@ jobs:
             docker logs "$c" 2>&1 | tail -100
           done
 
-  # Stable: retag RC image, push :version + :latest, publish crate
+  # Stable: build platform binaries
+  build-binaries:
+    needs: meta
+    if: needs.meta.outputs.is_rc == 'false'
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-musl
+            runner: ubuntu-latest
+            use_cross: true
+            artifact: plit-linux-x86_64
+          - target: i686-unknown-linux-musl
+            runner: ubuntu-latest
+            use_cross: true
+            artifact: plit-linux-i686
+          - target: aarch64-unknown-linux-musl
+            runner: ubuntu-latest
+            use_cross: true
+            artifact: plit-linux-aarch64
+          - target: x86_64-apple-darwin
+            runner: macos-13
+            use_cross: false
+            artifact: plit-darwin-x86_64
+          - target: aarch64-apple-darwin
+            runner: macos-latest
+            use_cross: false
+            artifact: plit-darwin-aarch64
+          - target: x86_64-pc-windows-msvc
+            runner: windows-latest
+            use_cross: false
+            artifact: plit-windows-x86_64
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - name: Install cross
+        if: matrix.use_cross
+        uses: taiki-e/install-action@cross
+
+      - name: Build (cross)
+        if: matrix.use_cross
+        run: cross build --release --target ${{ matrix.target }}
+
+      - name: Build (native)
+        if: "!matrix.use_cross"
+        run: cargo build --release --target ${{ matrix.target }}
+
+      - name: Package binaries (unix)
+        if: runner.os != 'Windows'
+        run: |
+          mkdir -p dist
+          cp target/${{ matrix.target }}/release/plit dist/
+          cp target/${{ matrix.target }}/release/plit-gw dist/
+          chmod +x dist/plit dist/plit-gw
+          tar czf ${{ matrix.artifact }}.tar.gz -C dist plit plit-gw
+
+      - name: Package binaries (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          New-Item -ItemType Directory -Force -Path dist
+          Copy-Item target/${{ matrix.target }}/release/plit.exe dist/
+          Copy-Item target/${{ matrix.target }}/release/plit-gw.exe dist/
+          Compress-Archive -Path dist/plit.exe, dist/plit-gw.exe -DestinationPath ${{ matrix.artifact }}.zip
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.artifact }}
+          path: ${{ matrix.artifact }}.*
+          if-no-files-found: error
+          retention-days: 1
+
+  # Stable: promote Docker image
   promote:
     needs: meta
     if: needs.meta.outputs.is_rc == 'false'
@@ -110,9 +189,7 @@ jobs:
 
       - name: Retag RC image as stable
         run: |
-          # Find the latest RC tag for this version
           VERSION="${{ needs.meta.outputs.version }}"
-          # Pull any RC image for this version (try rc.1, rc.2, etc. in reverse)
           for i in $(seq 10 -1 1); do
             RC_TAG="${VERSION}-rc.${i}"
             if docker pull ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${RC_TAG} 2>/dev/null; then
@@ -128,11 +205,22 @@ jobs:
           exit 1
 
   release:
-    needs: [meta, build, e2e, promote]
+    needs: [meta, build-docker, e2e, build-binaries, promote]
     if: always() && !failure() && !cancelled()
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
+      - name: Download all binary artifacts
+        if: needs.meta.outputs.is_rc == 'false'
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+          merge-multiple: true
+
+      - name: List artifacts
+        if: needs.meta.outputs.is_rc == 'false'
+        run: ls -la artifacts/ || true
 
       - name: Create GitHub Release
         uses: ncipollo/release-action@v1
@@ -142,7 +230,16 @@ jobs:
           prerelease: ${{ needs.meta.outputs.is_rc == 'true' }}
           makeLatest: ${{ needs.meta.outputs.is_rc == 'false' }}
           generateReleaseNotes: true
+          artifacts: artifacts/*
           body: |
+            ## Install
+
+            ```sh
+            curl -sSf https://raw.githubusercontent.com/theuselessai/plit/main/install.sh | sh
+            ```
+
+            Or download a binary below for your platform.
+
             ## Docker
 
             ```sh

--- a/README.md
+++ b/README.md
@@ -11,17 +11,23 @@
   <a href="#license"><img src="https://img.shields.io/badge/license-Apache%202.0-blue.svg?style=flat-square" alt="License: Apache 2.0" /></a>
 </p>
 
-**Supported platforms:** Linux (native), macOS (via Docker), Windows (via WSL2).
+**Supported platforms:** Linux, macOS, Windows, Raspberry Pi, iSH (iOS).
 
 ---
 
 ## Install
 
 ```sh
+curl -sSf https://raw.githubusercontent.com/theuselessai/plit/main/install.sh | sh
+```
+
+Or via Cargo:
+
+```sh
 cargo install plit
 ```
 
-This installs two binaries: `plit` (the CLI) and `plit-gw` (the gateway server).
+Pre-built static binaries are available for Linux (x86_64, aarch64, i686), macOS (Intel, Apple Silicon), and Windows.
 
 ---
 
@@ -49,11 +55,13 @@ Interactive wizard. Walks you through:
 - Configuring an LLM provider
 - Creating initial credentials
 
+On macOS and Windows, `plit init` detects the platform and switches to Docker mode automatically — pulling and running the [plit Docker image](https://github.com/orgs/theuselessai/packages/container/package/plit).
+
 Run this once before anything else.
 
 ### `plit start` / `plit stop`
 
-Start and stop the full stack: gateway, Pipelit, and background workers. Managed via honcho.
+Start and stop the full stack: gateway, Pipelit, and background workers. On Linux, managed via honcho. On macOS/Windows, managed via Docker.
 
 ```sh
 plit start

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,74 @@
+#!/bin/sh
+set -eu
+
+REPO="theuselessai/plit"
+INSTALL_DIR="${PLIT_INSTALL_DIR:-$HOME/.local/bin}"
+
+main() {
+    os=$(uname -s | tr '[:upper:]' '[:lower:]')
+    arch=$(uname -m)
+
+    case "$os" in
+        linux)  os_name="linux" ;;
+        darwin) os_name="darwin" ;;
+        *)      err "Unsupported OS: $os. Use 'cargo install plit' instead." ;;
+    esac
+
+    case "$arch" in
+        x86_64|amd64)   arch_name="x86_64" ;;
+        aarch64|arm64)  arch_name="aarch64" ;;
+        i686|i386)      arch_name="i686" ;;
+        *)              err "Unsupported architecture: $arch" ;;
+    esac
+
+    if [ "$os_name" = "darwin" ] && [ "$arch_name" = "i686" ]; then
+        err "macOS i686 is not supported"
+    fi
+
+    artifact="plit-${os_name}-${arch_name}"
+    archive="${artifact}.tar.gz"
+
+    latest_tag=$(curl -sSf "https://api.github.com/repos/${REPO}/releases/latest" \
+        | grep '"tag_name"' | head -1 | cut -d'"' -f4)
+
+    if [ -z "$latest_tag" ]; then
+        err "Could not determine latest release"
+    fi
+
+    url="https://github.com/${REPO}/releases/download/${latest_tag}/${archive}"
+
+    printf "Installing plit %s (%s/%s)\n" "$latest_tag" "$os_name" "$arch_name"
+    printf "  from: %s\n" "$url"
+    printf "  to:   %s\n\n" "$INSTALL_DIR"
+
+    mkdir -p "$INSTALL_DIR"
+
+    tmp=$(mktemp -d)
+    trap 'rm -rf "$tmp"' EXIT
+
+    curl -sSfL "$url" -o "$tmp/$archive" || err "Download failed. Check that ${archive} exists in release ${latest_tag}."
+    tar xzf "$tmp/$archive" -C "$tmp"
+
+    install -m 755 "$tmp/plit" "$INSTALL_DIR/plit"
+    install -m 755 "$tmp/plit-gw" "$INSTALL_DIR/plit-gw"
+
+    printf "\n  plit:    %s/plit\n" "$INSTALL_DIR"
+    printf "  plit-gw: %s/plit-gw\n\n" "$INSTALL_DIR"
+
+    case ":$PATH:" in
+        *":$INSTALL_DIR:"*) ;;
+        *)
+            printf "Add to your PATH:\n\n"
+            printf "  export PATH=\"%s:\$PATH\"\n\n" "$INSTALL_DIR"
+            ;;
+    esac
+
+    printf "Run 'plit init' to get started.\n"
+}
+
+err() {
+    printf "Error: %s\n" "$1" >&2
+    exit 1
+}
+
+main


### PR DESCRIPTION
## Summary

- Release workflow now cross-compiles platform binaries for 6 targets on stable releases
- New `install.sh` — one-liner curl installer for Linux and macOS
- README updated with curl install as primary method

## Binary Matrix

| Artifact | Target | Runner | Method |
|---|---|---|---|
| `plit-linux-x86_64.tar.gz` | `x86_64-unknown-linux-musl` | ubuntu | `cross` |
| `plit-linux-i686.tar.gz` | `i686-unknown-linux-musl` | ubuntu | `cross` |
| `plit-linux-aarch64.tar.gz` | `aarch64-unknown-linux-musl` | ubuntu | `cross` |
| `plit-darwin-x86_64.tar.gz` | `x86_64-apple-darwin` | macos-13 | native |
| `plit-darwin-aarch64.tar.gz` | `aarch64-apple-darwin` | macos-latest | native |
| `plit-windows-x86_64.zip` | `x86_64-pc-windows-msvc` | windows | native |

All Linux binaries are **statically linked via musl** — runs on any distro (Alpine, Debian, etc.), including iSH on iOS.

## Install Script

```sh
curl -sSf https://raw.githubusercontent.com/theuselessai/plit/main/install.sh | sh
```

Detects OS + arch, downloads correct binary from latest GitHub Release, installs to `~/.local/bin/`.

## Release Workflow Changes

- RC: Docker image + E2E (unchanged)
- Stable: Docker promote + **platform binary builds** + GitHub Release with binary assets + crates.io

Closes #9